### PR TITLE
Added a patch with fixes for 64 bit.

### DIFF
--- a/patches/gdc/0021-Fixes-for-64-bit.patch
+++ b/patches/gdc/0021-Fixes-for-64-bit.patch
@@ -1,0 +1,93 @@
+From 15f2765206ca560b6fdcce0fe857ad50696e9aae Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jernej=20Krempu=C5=A1?= <jkrempus@gmail.com>
+Date: Wed, 27 Nov 2013 02:58:37 -0800
+Subject: [PATCH] Fixes for 64 bit
+
+- fixed linker errors
+- corrected a check for MinGW64 in thread.d (fixes fibers)
+---
+ libphobos/libdruntime/core/thread.d | 32 +++++++++++++++++++++-----------
+ libphobos/libdruntime/rt/memory.d   |  8 ++++----
+ 2 files changed, 25 insertions(+), 15 deletions(-)
+
+diff --git a/libphobos/libdruntime/core/thread.d b/libphobos/libdruntime/core/thread.d
+index f9507c7..15428be 100644
+--- a/libphobos/libdruntime/core/thread.d
++++ b/libphobos/libdruntime/core/thread.d
+@@ -14,6 +14,7 @@ module core.thread;
+ 
+ public import core.time; // for Duration
+ static import rt.tlsgc;
++import core.stdc.stdio;
+ 
+ // this should be true for most architectures
+ version( GNU_StackGrowsDown )
+@@ -3188,18 +3189,21 @@ private
+     }
+     else version( GNU_InlineAsm )
+     {
+-        version( MinGW64 )
++        version( MinGW)
+         {
+-            version = GNU_AsmX86_64_Windows;
+-            version = AlignFiberStackTo16Byte;
+-			version = AsmExternal;
++            version(X86_64)
++            {
++                version = GNU_AsmX86_64_Windows;
++                version = AlignFiberStackTo16Byte;
++                version = AsmExternal;
++            }
++            else
++            {
++                version = GNU_AsmX86_Windows;
++                version = AlignFiberStackTo16Byte;
++                version = AsmExternal;
++            }
+         }
+-        else version( MinGW )
+-        {
+-            version = GNU_AsmX86_Windows;
+-            version = AlignFiberStackTo16Byte;
+-			version = AsmExternal;
+-        } 
+     }	
+     else version( PPC )
+     {
+@@ -3303,7 +3307,13 @@ private
+     }
+ 
+   version( AsmExternal )
+-    extern (C) void fiber_switchContext( void** oldp, void* newp );
++  {
++    version(MinGW)
++      extern (C) pragma(mangle, "_fiber_switchContext") 
++	  void fiber_switchContext( void** oldp, void* newp );
++    else
++      extern (C) void fiber_switchContext( void** oldp, void* newp );
++  }
+   else
+     extern (C) void fiber_switchContext( void** oldp, void* newp )
+     {
+diff --git a/libphobos/libdruntime/rt/memory.d b/libphobos/libdruntime/rt/memory.d
+index 2e29a0f..e2e9c52 100644
+--- a/libphobos/libdruntime/rt/memory.d
++++ b/libphobos/libdruntime/rt/memory.d
+@@ -24,10 +24,10 @@ private
+         {
+             extern __gshared
+             {
+-                int _data_start__;
+-                int _data_end__;
+-                int _bss_start__;
+-                int _bss_end__;
++                pragma(mangle, "__data_start__") int _data_start__;
++                pragma(mangle, "__data_end__") int _data_end__;
++                pragma(mangle, "__bss_start__") int _bss_start__;
++                pragma(mangle, "__bss_end__") int _bss_end__;
+             }
+         }
+     }
+-- 
+1.8.4.msysgit.0
+

--- a/patches/gdc/0021-Fixes-for-64-bit.patch
+++ b/patches/gdc/0021-Fixes-for-64-bit.patch
@@ -1,4 +1,4 @@
-From 15f2765206ca560b6fdcce0fe857ad50696e9aae Mon Sep 17 00:00:00 2001
+From 6bd7271aa2cc7ef02fd51c82659f03db90be443c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Jernej=20Krempu=C5=A1?= <jkrempus@gmail.com>
 Date: Wed, 27 Nov 2013 02:58:37 -0800
 Subject: [PATCH] Fixes for 64 bit
@@ -6,12 +6,45 @@ Subject: [PATCH] Fixes for 64 bit
 - fixed linker errors
 - corrected a check for MinGW64 in thread.d (fixes fibers)
 ---
- libphobos/libdruntime/core/thread.d | 32 +++++++++++++++++++++-----------
- libphobos/libdruntime/rt/memory.d   |  8 ++++----
- 2 files changed, 25 insertions(+), 15 deletions(-)
+ libphobos/libdruntime/core/sys/windows/mingwasm.S |  8 +++++---
+ libphobos/libdruntime/core/thread.d               | 24 +++++++++++++----------
+ libphobos/libdruntime/rt/memory.d                 | 18 +++++++++++++----
+ 3 files changed, 33 insertions(+), 17 deletions(-)
 
+diff --git a/libphobos/libdruntime/core/sys/windows/mingwasm.S b/libphobos/libdruntime/core/sys/windows/mingwasm.S
+index 16cf089..55b3835 100644
+--- a/libphobos/libdruntime/core/sys/windows/mingwasm.S
++++ b/libphobos/libdruntime/core/sys/windows/mingwasm.S
+@@ -1,9 +1,9 @@
+ /**
+  * Support code for MinGW fibers.
+  */
+- 	.global	_fiber_switchContext
+-_fiber_switchContext:
+ #if defined(__x86_64__)
++ 	.global	fiber_switchContext
++fiber_switchContext:
+ 	// save current stack state
+     pushq %RBP;
+     movq  %RSP, %RBP;
+@@ -36,6 +36,8 @@ _fiber_switchContext:
+     popq %RCX;
+     jmp *%RCX;
+ #elif defined(__x86__)
++ 	.global	_fiber_switchContext
++_fiber_switchContext:
+ 	// Save current stack state.save current stack state
+ 	// Standard CDECL prologue.  
+ 	push %EBP;
+@@ -68,4 +70,4 @@ _fiber_switchContext:
+     ret;
+ #else
+ // assert?
+-#endif
+\ No newline at end of file
++#endif
 diff --git a/libphobos/libdruntime/core/thread.d b/libphobos/libdruntime/core/thread.d
-index f9507c7..15428be 100644
+index f9507c7..304deca 100644
 --- a/libphobos/libdruntime/core/thread.d
 +++ b/libphobos/libdruntime/core/thread.d
 @@ -14,6 +14,7 @@ module core.thread;
@@ -27,12 +60,12 @@ index f9507c7..15428be 100644
      else version( GNU_InlineAsm )
      {
 -        version( MinGW64 )
-+        version( MinGW)
++        version( MinGW )
          {
 -            version = GNU_AsmX86_64_Windows;
 -            version = AlignFiberStackTo16Byte;
 -			version = AsmExternal;
-+            version(X86_64)
++            version( X86_64 )
 +            {
 +                version = GNU_AsmX86_64_Windows;
 +                version = AlignFiberStackTo16Byte;
@@ -54,26 +87,11 @@ index f9507c7..15428be 100644
      }	
      else version( PPC )
      {
-@@ -3303,7 +3307,13 @@ private
-     }
- 
-   version( AsmExternal )
--    extern (C) void fiber_switchContext( void** oldp, void* newp );
-+  {
-+    version(MinGW)
-+      extern (C) pragma(mangle, "_fiber_switchContext") 
-+	  void fiber_switchContext( void** oldp, void* newp );
-+    else
-+      extern (C) void fiber_switchContext( void** oldp, void* newp );
-+  }
-   else
-     extern (C) void fiber_switchContext( void** oldp, void* newp )
-     {
 diff --git a/libphobos/libdruntime/rt/memory.d b/libphobos/libdruntime/rt/memory.d
-index 2e29a0f..e2e9c52 100644
+index 2e29a0f..5a452a0 100644
 --- a/libphobos/libdruntime/rt/memory.d
 +++ b/libphobos/libdruntime/rt/memory.d
-@@ -24,10 +24,10 @@ private
+@@ -24,10 +24,20 @@ private
          {
              extern __gshared
              {
@@ -81,6 +99,16 @@ index 2e29a0f..e2e9c52 100644
 -                int _data_end__;
 -                int _bss_start__;
 -                int _bss_end__;
++                // We need to use pragma mangle here to get correct
++                // mangled symbol names on both Win32 and Win64. The 
++                // problem is that _ gets prepended to symbol names 
++                // on Win32, but not on Win64. The symbols __data_start__, 
++                // __data_end__, __bss_start__ and __bss_end__ ,
++                // on the other hand, are the same on Win32 and Win64. 
++                // Maybe those names should be changed to _data_start__ 
++                // etc. on Win64, but until they are, we need to make 
++                // sure that we always use mangled names __data_start__ etc.
++
 +                pragma(mangle, "__data_start__") int _data_start__;
 +                pragma(mangle, "__data_end__") int _data_end__;
 +                pragma(mangle, "__bss_start__") int _bss_start__;


### PR DESCRIPTION
This patch fixes a few linker errors and a wrong check for MinGW64 in thread.d that caused Fiber.call() to fail.
